### PR TITLE
Event tracking updates

### DIFF
--- a/templates/sfxmenu/sfxmenu.tmpl
+++ b/templates/sfxmenu/sfxmenu.tmpl
@@ -48,7 +48,7 @@
 		<![endif]-->
 
 		<script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
-		<script src="https://liblet.lib.uchicago.edu/static/base/js/jquery.track-everything.js"></script>
+		<script src="https://www.lib.uchicago.edu/static/base/js/jquery.track-everything.js"></script>
 
 		<script type="text/javascript">
 


### PR DESCRIPTION
- changes HTML `data-ga-*` properties according to new schema;
- ~changes the link to the tracking script to the one on `nest` during testing phase. It will need to be reverted back to the main website once the script is actually published.~
- removed outdated tracking code call, and reverted the subnet class to a console log instead of a GA submission.